### PR TITLE
Add "check_code.sh" call to test_all.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Install @package@ package
     # Assuming you followed the fully supported installation,
     # using $GEOIPS_PACKAGES_DIR and $GEOIPS_CONFIG_FILE:
     source $GEOIPS_CONFIG_FILE
-    git clone $GEOIPS_REPO_URL/@package@ $GEOIPS_PACKAGES_DIR/@package@
+    git clone https://github.com/NRLMMD-GEOIPS/@package@ $GEOIPS_PACKAGES_DIR/@package@
     pip install -e $GEOIPS_PACKAGES_DIR/@package@
 ```
 

--- a/tests/test_all.sh
+++ b/tests/test_all.sh
@@ -33,6 +33,7 @@ echo ""
 # "call" used in test_all_run.sh
 for call in \
 \
+            "$GEOIPS_PACKAGES_DIR/geoips/tests/utils/check_code.sh all `dirname $0`/../" \
             "$GEOIPS_PACKAGES_DIR/@package@/tests/scripts/test_config.sh" \
             "$GEOIPS_PACKAGES_DIR/@package@/tests/scripts/@mydatatype@.tc.@product@.imagery_clean.sh"
 do


### PR DESCRIPTION
To facilitate early code style enforcement, include the "check_code.sh" call to the "standard" test_all.sh script.

check_code.sh calls black, flake8, and bandit for code style enforcements.
