### PR TITLE
Update colormaps->colormappers in reference

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,8 @@ dynamic = ["version"]
 # @ Add your own required entry points, based on your new functionality
 # [project.entry-points."geoips.algorithms"]
 # "@my_alg@" = "@package@.plugins.modules.algorithms.@my_alg@"
-# [project.entry-points."geoips.colormaps"]
-# "@my_cmap@" = "@package@.plugins.modules.colormaps.@my_cmap@"
+# [project.entry-points."geoips.colormappers"]
+# "@my_cmap@" = "@package@.plugins.modules.colormappers.@my_cmap@"
 # [project.entry-points."geoips.interpolators"]
 # "@my_interp@" = "@package@.plugins.modules.interpolators.@my_interp@"
 # [project.entry-points."geoips.output_formatters"]


### PR DESCRIPTION
Commented out entry point was named colormaps, should be colormappers.

This is just the comment - no functionality changed.